### PR TITLE
nEXT is the only maintained web browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ For more, see [Awesome-cl](https://github.com/CodyReichert/awesome-cl).
 ### Internet
 #### Browser
 
-- [Closure](https://github.com/dym/closure) - a web browser implemented in Common Lisp. [MIT](https://opensource.org/licenses/MIT).
-- [Lispkit](https://github.com/AeroNotix/lispkit) - A lisp web browser using WebKit. [2-clause BSD].
 - [nEXT](https://github.com/nEXT-Browser/nEXT) -  nEXT - The fastest productivity web-browser.
+
+See also [Closure](https://github.com/dym/closure) (using McClim) and [Lispkit](https://github.com/AeroNotix/lispkit) (using WebKit).
 
 
 ### Operating System


### PR DESCRIPTION
Hello,

I don't like this list to not being a minimum curated and listing altogether unmaintained and current software. So I wonder if you would accept this solution: we list properly the maintained software (nEXT browser) and still reference others, but below (Closure, Lispkit), with less details. Is that ok for you ?

This could fix https://github.com/CodyReichert/awesome-cl/pull/127.

Regards